### PR TITLE
Attempts on issue #43

### DIFF
--- a/dapper/mods/Ikeda/__init__.py
+++ b/dapper/mods/Ikeda/__init__.py
@@ -59,7 +59,7 @@ params = dict(labels='xy')
 
 
 def LPs(jj=None, params=params): return [
-    (14, 1, LP.sliding_marginals(obs_inds=jj, zoomy=0.8, **params)),
-    (13, 1, LP.phase_particles(
+    (1, LP.sliding_marginals(obs_inds=jj, zoomy=0.8, **params)),
+    (1, LP.phase_particles(
         is_3d=False, obs_inds=jj, zoom=0.8, Tplot=0, **params)),
 ]

--- a/dapper/mods/Lorenz63/__init__.py
+++ b/dapper/mods/Lorenz63/__init__.py
@@ -72,7 +72,7 @@ params = dict(labels='xyz', Tplot=1)
 
 
 def LPs(jj=None, params=params): return [
-    (12, 1, LP.correlations),
-    (14, 1, LP.sliding_marginals(jj, zoomy=0.8, **params)),
-    (13, 1, LP.phase_particles(is_3d=True, obs_inds=jj, **params)),
+    (1, LP.correlations),
+    (1, LP.sliding_marginals(jj, zoomy=0.8, **params)),
+    (1, LP.phase_particles(is_3d=True, obs_inds=jj, **params)),
 ]

--- a/dapper/mods/Lorenz96/__init__.py
+++ b/dapper/mods/Lorenz96/__init__.py
@@ -64,9 +64,9 @@ def dstep_dx(x, t, dt):
 # Add some non-default liveplotters
 ################################################
 def LPs(jj=None): return [
-    (11, 1, LP.spatial1d(jj)),
-    (12, 1, LP.correlations),
-    (15, 0, LP.spectral_errors),
-    (13, 0, LP.phase_particles(True, jj)),
-    (14, 0, LP.sliding_marginals(jj)),
+    (1, LP.spatial1d(jj)),
+    (1, LP.correlations),
+    (0, LP.spectral_errors),
+    (0, LP.phase_particles(True, jj)),
+    (0, LP.sliding_marginals(jj)),
 ]

--- a/dapper/mods/LorenzUV/__init__.py
+++ b/dapper/mods/LorenzUV/__init__.py
@@ -113,4 +113,4 @@ class model_instance():
         return integrate_TLM(self.d2x_dtdx_auto(x), dt, method='analytic')
 
     def LPs(self, jj):
-        return [(11, 1, LP.spatial1d(jj, dims=list(range(self.nU))))]
+        return [(1, LP.spatial1d(jj, dims=list(range(self.nU))))]

--- a/dapper/mods/QG/__init__.py
+++ b/dapper/mods/QG/__init__.py
@@ -177,7 +177,7 @@ cntr = nx*int(ny/2) + int(0.5*nx)
 
 
 def LP_setup(jj=None): return [
-    (11, 1, LP.spatial2d(square, ind2sub, jj, cm)),
-    (15, 0, LP.spectral_errors),
-    (14, 0, LP.sliding_marginals(dims=cntr+np.arange(4))),
+    (1, LP.spatial2d(square, ind2sub, jj, cm)),
+    (0, LP.spectral_errors),
+    (0, LP.sliding_marginals(dims=cntr+np.arange(4))),
 ]

--- a/dapper/mods/__init__.py
+++ b/dapper/mods/__init__.py
@@ -95,6 +95,33 @@ class HiddenMarkovModel(struct_tools.NicePrint):
     also known as "twin experiment", or OSSE (observing system simulation experiment).
     The synthetic truth and observations may then be obtained by running
     `HiddenMarkovModel.simulate`.
+
+    See scripts in examples for more details.
+
+    Parameters
+    ----------
+    Dyn: `Operator` or dict
+        Operator for the dynamical model, contains model stepping ('model'),
+        model size ('M') and model noise ('noise'), etc.
+    Obs: `Operator` or dict
+        Operator for the dynamical model, contains model stepping ('model'),
+        model size ('M') and model noise ('noise'), etc.
+    t: `dapper.tools.chronos.Chronology`
+        Time schedules of the HMM.
+    X0: `dapper.tools.randvars.RV`
+        Random distribution as initial condition
+    liveplotters: `list`, optional
+        A list of tuples. See example use in function `LPs` of `dapper.mods.Lorenz63`.
+        - The first element of the tuple determines whether the liveplotter is shown if
+        the names of liveplotters are not given by `liveplots` argument in
+        `assimilate`.
+        - The second element in the tuple gives the corresponding liveplotter
+        function/class.
+    sectors: `dict`, optional
+        The sectors divide each state vectors into different sectors.
+        See example in `param_estim.py` in the examples directory.
+    name: str, optional
+        Specify a name for the instantiated `HMM`.
     """
 
     def __init__(self, *args, **kwargs):

--- a/dapper/mods/__init__.py
+++ b/dapper/mods/__init__.py
@@ -101,27 +101,25 @@ class HiddenMarkovModel(struct_tools.NicePrint):
     Parameters
     ----------
     Dyn: `Operator` or dict
-        Operator for the dynamical model, contains model stepping ('model'),
-        model size ('M') and model noise ('noise'), etc.
+        Operator for the dynamics.
     Obs: `Operator` or dict
-        Operator for the dynamical model, contains model stepping ('model'),
-        model size ('M') and model noise ('noise'), etc.
+        Operator for the observations
     t: `dapper.tools.chronos.Chronology`
-        Time schedules of the HMM.
+        Time sequence of the HMM process.
     X0: `dapper.tools.randvars.RV`
-        Random distribution as initial condition
+        Random distribution of initial condition
     liveplotters: `list`, optional
         A list of tuples. See example use in function `LPs` of `dapper.mods.Lorenz63`.
-        - The first element of the tuple determines whether the liveplotter is shown if
-        the names of liveplotters are not given by `liveplots` argument in
-        `assimilate`.
+        - The first element of the tuple determines if the liveplotter is shown by default.
+        If `False`, the liveplotter is only shown when included among the `liveplots` argument of `assimilate`
         - The second element in the tuple gives the corresponding liveplotter
         function/class.
     sectors: `dict`, optional
-        The sectors divide each state vectors into different sectors.
-        See example in `param_estim.py` in the examples directory.
+        Labelled indices referring to parts of the state vector.
+        When defined, field-mean statistics are computed for each sector.
+        Example use can be found in  `examples/param_estim.py` and `dapper/mods/Lorenz96/miyoshi2011.py`
     name: str, optional
-        Specify a name for the instantiated `HMM`.
+        Label for the `HMM`.
     """
 
     def __init__(self, *args, **kwargs):

--- a/dapper/mods/__init__.py
+++ b/dapper/mods/__init__.py
@@ -110,14 +110,16 @@ class HiddenMarkovModel(struct_tools.NicePrint):
         Random distribution of initial condition
     liveplotters: `list`, optional
         A list of tuples. See example use in function `LPs` of `dapper.mods.Lorenz63`.
-        - The first element of the tuple determines if the liveplotter is shown by default.
-        If `False`, the liveplotter is only shown when included among the `liveplots` argument of `assimilate`
+        - The first element of the tuple determines if the liveplotter
+        is shown by default. If `False`, the liveplotter is only shown when
+        included among the `liveplots` argument of `assimilate`
         - The second element in the tuple gives the corresponding liveplotter
         function/class.
     sectors: `dict`, optional
         Labelled indices referring to parts of the state vector.
         When defined, field-mean statistics are computed for each sector.
-        Example use can be found in  `examples/param_estim.py` and `dapper/mods/Lorenz96/miyoshi2011.py`
+        Example use can be found in  `examples/param_estim.py`
+        and `dapper/mods/Lorenz96/miyoshi2011.py`
     name: str, optional
         Label for the `HMM`.
     """

--- a/dapper/stats.py
+++ b/dapper/stats.py
@@ -450,9 +450,9 @@ class Stats(StatPrint):
         # Pause required when speed=inf.
         # On Mac, it was also necessary to do it for each fig.
         if LP.any_figs:
-            for _name, (num, updater) in LP.figures.items():
-                if plt.fignum_exists(num) and getattr(updater, 'is_active', 1):
-                    plt.figure(num)
+            for _name, (updater) in LP.figures.items():
+                if plt.fignum_exists(_name) and getattr(updater, 'is_active', 1):
+                    plt.figure(_name)
                     plt.pause(0.01)
 
 

--- a/dapper/stats.py
+++ b/dapper/stats.py
@@ -450,7 +450,7 @@ class Stats(StatPrint):
         # Pause required when speed=inf.
         # On Mac, it was also necessary to do it for each fig.
         if LP.any_figs:
-            for _name, (updater) in LP.figures.items():
+            for _name, updater in LP.figures.items():
                 if plt.fignum_exists(_name) and getattr(updater, 'is_active', 1):
                     plt.figure(_name)
                     plt.pause(0.01)

--- a/dapper/tools/liveplotting.py
+++ b/dapper/tools/liveplotting.py
@@ -1,4 +1,25 @@
-"""On-line (live) plots of the DA process for various models and methods."""
+"""On-line (live) plots of the DA process for various models and methods.
+
+Liveplotters are given by a list of tuples as property or arguments in
+`dapper.mods.HiddenMarkovModel`.
+
+- The first element of the tuple determines whether the liveplotter is shown if
+the names of liveplotters are not given by `liveplots` argument in
+`assimilate`.
+
+- The second element in the tuple gives the corresponding liveplotter
+function/class. See example of function `LPs` in `dapper.mods.Lorenz63`.
+
+The liveplotters can be fine-tuned by each DA experiments via argument of
+`liveplots` when calling `assimilate`.
+
+- `liveplots = True` turns on liveplotters set to default in the first
+argument of the `HMM.liveplotter` and default liveplotters defined in this module
+(`sliding_diagnostics` and `weight_histogram`).
+
+- `liveplots` can also be a list of specified names of liveplotter, which
+is the name of the corresponding liveplotting classes/functions.
+"""
 
 import matplotlib as mpl
 import numpy as np
@@ -90,26 +111,24 @@ class LivePlot:
 
         # Set up dict of liveplotters
         potential_LPs = {}
-        for num, show, init in default_liveplotters:
-            potential_LPs[get_name(init)] = num, show, init
+        for show, init in default_liveplotters:
+            potential_LPs[get_name(init)] = show, init
         # Add HMM-specific liveplotters
-        for num, show, init in getattr(stats.HMM, 'liveplotters', {}):
-            assert num > 10, ("Liveplotters specified in the HMM"
-                              " should have fignum>10.")
-            potential_LPs[get_name(init)] = num, show, init
+        for show, init in getattr(stats.HMM, 'liveplotters', {}):
+            potential_LPs[get_name(init)] = show, init
 
         def parse_figlist(lst):
             """Figures requested for this xp. Convert to list."""
             if isinstance(lst, str):
                 fn = lst.lower()
                 if "all" == fn:
-                    lst = range(99)  # All potential_LPs
+                    lst = ["all"]  # All potential_LPs
                 elif "default" in fn:
-                    lst = []         # All show_by_default
+                    lst = ["default"]         # All show_by_default
             elif hasattr(lst, '__len__'):
                 lst = lst            # This list (only)
             elif lst:
-                lst = []             # All show_by_default
+                lst = ["default"]             # All show_by_default
             else:
                 lst = [None]         # None
             return lst
@@ -117,10 +136,10 @@ class LivePlot:
 
         # Loop over requeted figures
         self.figures = {}
-        for name, (num, show_by_default, init) in potential_LPs.items():
-            if (num in figlist) or \
+        for name, (show_by_default, init) in potential_LPs.items():
+            if (figlist == ["all"]) or \
                     (name in figlist) or \
-                    (figlist == [] and show_by_default):
+                    (figlist == ["default"] and show_by_default):
 
                 # Startup message
                 if not self.any_figs:
@@ -146,13 +165,13 @@ class LivePlot:
 
                 # Init figure
                 post_title = "" if self.plot_u else "\n(obs times only)"
-                updater = init(num, stats, key0, self.plot_u, E, P, **kwargs)
-                if plt.fignum_exists(num) and getattr(updater, 'is_active', 1):
-                    self.figures[name] = (num, updater)
-                    fig = plt.figure(num)
+                updater = init(name, stats, key0, self.plot_u, E, P, **kwargs)
+                if plt.fignum_exists(name) and getattr(updater, 'is_active', 1):
+                    self.figures[name] = updater
+                    fig = plt.figure(name)
                     win = fig.canvas
                     ax0 = fig.axes[0]
-                    win.set_window_title("%s [%d]" % (name, num))
+                    win.set_window_title("%s" % name)
                     ax0.set_title(ax0.get_title() + post_title)
                     self.update(key0, E, P)  # Call initial update
                     plt.pause(0.01)          # Draw
@@ -161,8 +180,8 @@ class LivePlot:
         """Update liveplots"""
         # Check if there are still open figures
         if self.any_figs:
-            open_figns = plt.get_fignums()
-            live_figns = {num for (num, updater) in self.figures.values()}
+            open_figns = [plt.figure(i).get_label() for i in plt.get_fignums()]
+            live_figns = set(self.figures.keys())
             self.any_figs = bool(live_figns.intersection(open_figns))
         else:
             return
@@ -220,10 +239,10 @@ class LivePlot:
         if not self.skipping:
             faus = key[-1]
             if faus != 'u' or self.plot_u:
-                for _name, (num, updater) in self.figures.items():
-                    if plt.fignum_exists(num) and \
+                for _name, (updater) in self.figures.items():
+                    if plt.fignum_exists(_name) and \
                             getattr(updater, 'is_active', 1):
-                        _ = plt.figure(num)
+                        _ = plt.figure(_name)
                         updater(key, E, P)
                         plot_pause(self.params['pause_'+faus])
 
@@ -1322,6 +1341,6 @@ def spatial2d(
 # - show_by_default
 # - function/class
 default_liveplotters = [
-    (1, 1, sliding_diagnostics),
-    (4, 1, weight_histogram),
+    (1, sliding_diagnostics),
+    (1, weight_histogram),
 ]

--- a/examples/param_estim.py
+++ b/examples/param_estim.py
@@ -94,8 +94,8 @@ Obs['noise'] = 1
 
 # Specify liveplotting (and replay) functionality.
 LP = [
-    (11, 1, LP.spatial1d(jj)),
-    (14, 1, LP.sliding_marginals(
+    (1, LP.spatial1d(jj)),
+    (1, LP.sliding_marginals(
         jj, zoomy=0.8, dims=[0, Nx], labels=["$x_0$", "Force"]),
      ),
 ]


### PR DESCRIPTION
This is my attempt to tackle issue #43.

I feel that creating a pull request is an easier way to show the difference between codes as it is not trivial. If you have a better practice for doing this, let me know. 

I hope I understand your needs correctly, here are some changes:
- I use the `name` of the liveplotter as the `num` arguments of the `fig = plt.figure(num)` instead of integers (See matplotlib doc [here](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.figure.html) ). This treatment leads to automatic assignment of `fig.number` and the `str` type name can be accessed via `fig.get_label()` (An example use in dapper is [here](https://github.com/yumengch/DAPPER/blob/98aac5ab650d03382a1d164901545487c85e043a/dapper/tools/liveplotting.py#L183) ). 
- Hence, I removed all assignment of `fignum` in LP definitions in dapper (and I hope I find all).
- The consequence is that, in the `assimilate` calls, we **cannot specify selected liveplots via `fignum`** but have to specify via the `name` of the figures, e.g. `sliding_diagnostics`. I didn't change much in the function [`parse_figlist`](https://github.com/yumengch/DAPPER/blob/98aac5ab650d03382a1d164901545487c85e043a/dapper/tools/liveplotting.py#L120) as I think the option with a list of liveplotter names was already implemented.
- Hence, these changes keep the following feature:
> - Being able to reference a subset of the available LPs (HMM.liveplotters) when running experiments, to only plot the selected ones.
> - Clearing the figures rather than creating new ones. This keeps figure position and size on screen, which I find to be very helpful. Note that in the most recent installs of DAPPER the freshfig function works quite well with pre-saved figure positions (on linux at least). This does not require specific figure numbers, but the positions are associated with a given fig number, so fig. number persistence is required.
- Note the fig number persistence is achieved via the name of the liveplotting functions/classes.
- The fuzzy match is not supported and I'm also a bit in doubt about the necessity here.
- I added some documentation for `HMM` and `liveplotting.py` in the hope that the use of liveplotters can be clearer in the doc.
- This pull request has passed the `tests/test_plotting.py`.

Hope this pull request is helpful.