### PR TITLE
Swap dxdt args

### DIFF
--- a/dapper/mods/Lorenz96/__init__.py
+++ b/dapper/mods/Lorenz96/__init__.py
@@ -39,4 +39,4 @@ def dxdt(x):
 
 
 def step(x0, t, dt):
-    return rk4(lambda t, x: dxdt(x), x0, np.nan, dt)
+    return rk4(lambda x, t: dxdt(x), x0, np.nan, dt)

--- a/dapper/mods/Lorenz96s/__init__.py
+++ b/dapper/mods/Lorenz96s/__init__.py
@@ -131,13 +131,13 @@ def l96s_tay2_step(x, t, dt, s):
 def em_ensemble_step(x0, t, dt):
     """Euler-Maruyama (order 1.0 Weak / Strong) model step wrapper"""
 
-    return rk4(lambda t, x: dxdt(x), x0, np.nan, dt, s=diffusion, stages=1)
+    return rk4(lambda x, t: dxdt(x), x0, np.nan, dt, s=diffusion, stages=1)
 
 
 def rk_ensemble_step(x0, t, dt):
     """4-stage Runge-Kutta (order 1.0 Weak / Strong) model step wrapper"""
 
-    return rk4(lambda t, x: dxdt(x), x0, np.nan, dt, s=diffusion, stages=4)
+    return rk4(lambda x, t: dxdt(x), x0, np.nan, dt, s=diffusion, stages=4)
 
 
 # define the numerical step model for the truth twin

--- a/dapper/mods/LorenzIII/__init__.py
+++ b/dapper/mods/LorenzIII/__init__.py
@@ -87,7 +87,7 @@ class Model:
         )
 
     def step1(self, x0, t, dt):
-        return rk4(lambda t, x: self.dxdt(x), x0, np.nan, dt)
+        return rk4(lambda x, t: self.dxdt(x), x0, np.nan, dt)
     # Note: step1 is already ensemble compatible.
     # However, it is a bit slow, so we can gain in speed by using multiprocessing.
 

--- a/dapper/mods/LorenzUV/__init__.py
+++ b/dapper/mods/LorenzUV/__init__.py
@@ -78,10 +78,10 @@ class model_instance():
         assert x.shape[-1] == self.nU
         return dxdt_auto(x) + self.F
 
-    def dxdt_parameterized(self, t, x):
+    def dxdt_parameterized(self, x, t):
         """Compute truncated `dxdt` with parameterization of fast variables (`V`)."""
         d  = self.dxdt_trunc(x)
-        d -= self.prmzt(t, x)  # must (of course) be set first
+        d -= self.prmzt(x, t)  # must (of course) be set first
         return d
 
     def dxdt(self, x):

--- a/dapper/mods/LorenzUV/wilks05.py
+++ b/dapper/mods/LorenzUV/wilks05.py
@@ -66,10 +66,10 @@ Obs['noise'] = R
 other = {'name': rel2mods(__file__)+'_trunc'}
 HMM_trunc = modelling.HiddenMarkovModel(Dyn, Obs, t, X0, LP=LUV.LPs(jj), **other)
 
-LUV.prmzt = lambda t, x: polynom_prmzt(t, x, 1)
+LUV.prmzt = lambda x, t: polynom_prmzt(x, t, 1)
 
 
-def polynom_prmzt(t, x, order):
+def polynom_prmzt(x, t, order):
     """
     Polynomial (deterministic) parameterization of fast variables (Y).
 

--- a/dapper/mods/integration.py
+++ b/dapper/mods/integration.py
@@ -14,12 +14,12 @@ def rk4(f, x, t, dt, stages=4, s=0):
     """Runge-Kutta (explicit, non-adaptive) numerical (S)ODE solvers.
 
     For ODEs, the order of convergence equals the number of `stages`.
+
     For SDEs with additive noise (`s>0`), the order of convergence
-    (both weak and strong) is 1 for `stages` equal to one or four.
+    (both weak and strong) is 1 for `stages` equal to 1 or 4.
     These correspond to the classic Euler-Maruyama scheme and the Runge-Kutta
-    scheme for SODEs respectively, see `bib.grudzien2020numerical`
-    for a DA-specific discussion on integration schemes and their
-    discretization errors.
+    scheme for S-ODEs respectively, see `bib.grudzien2020numerical`
+    for a DA-specific discussion on integration schemes and their discretization errors.
 
     Parameters
     ----------

--- a/dapper/mods/integration.py
+++ b/dapper/mods/integration.py
@@ -57,18 +57,18 @@ def rk4(f, x, t, dt, stages=4, s=0):
         W = 0
 
     # Approximations to Delta x
-    if stages >= 1: k1 = dt * f(t       , x)           + W   # noqa
-    if stages >= 2: k2 = dt * f(t+dt/2.0, x+k1/2.0)    + W   # noqa
-    if stages == 3: k3 = dt * f(t+dt    , x+k2*2.0-k1) + W   # noqa
+    if stages >= 1: k1 = dt * f(x,           t)         + W    # noqa
+    if stages >= 2: k2 = dt * f(x+k1/2.0,    t+dt/2.0)  + W    # noqa
+    if stages == 3: k3 = dt * f(x+k2*2.0-k1, t+dt)      + W    # noqa
     if stages == 4:
-                    k3 = dt * f(t+dt/2.0, x+k2/2.0)    + W   # noqa
-                    k4 = dt * f(t+dt    , x+k3)        + W   # noqa
+                    k3 = dt * f(x+k2/2.0,    t+dt/2.0)  + W    # noqa
+                    k4 = dt * f(x+k3,        t+dt)      + W    # noqa
 
     # Mix proxies
-    if    stages == 1: y = x + k1                            # noqa
-    elif  stages == 2: y = x + k2                            # noqa
-    elif  stages == 3: y = x + (k1 + 4.0*k2 + k3)/6.0        # noqa
-    elif  stages == 4: y = x + (k1 + 2.0*(k2 + k3) + k4)/6.0 # noqa
+    if    stages == 1: y = x + k1                              # noqa
+    elif  stages == 2: y = x + k2                              # noqa
+    elif  stages == 3: y = x + (k1 + 4.0*k2 + k3)/6.0          # noqa
+    elif  stages == 4: y = x + (k1 + 2.0*(k2 + k3) + k4)/6.0   # noqa
     else:
         raise NotImplementedError
 
@@ -77,11 +77,11 @@ def rk4(f, x, t, dt, stages=4, s=0):
 
 def with_rk4(dxdt, autonom=False, stages=4, s=0):
     """Wrap `dxdt` in `rk4`."""
-    def tendency(t, x):
+    def tendency(x, t):
         if autonom:
             return dxdt(x)
         else:
-            return dxdt(t, x)
+            return dxdt(x, t)
 
     def step(x0, t0, dt):
         return rk4(tendency, x0, t0, dt, stages=stages)
@@ -176,7 +176,7 @@ def integrate_TLM(TLM, dt, method='approx'):
     else:
         Id = np.eye(TLM.shape[0])
         if method == 'rk4':
-            resolvent = rk4(lambda t, U: TLM@U, Id, np.nan, dt)
+            resolvent = rk4(lambda U, t: TLM@U, Id, np.nan, dt)
         elif method.lower().startswith('approx'):
             resolvent = Id + dt*TLM
         else:


### PR DESCRIPTION
Making `x` the first arg enables using `ens_compatible` also when `dxdt` is a function of `t`.