### PR TITLE
Dev install

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Ensure the printed version is 3.7 or more.
 - Move the resulting folder wherever you like,  
   and `cd` into it
   *(ensure you're in the folder with a `setup.py` file)*.
-- `pip install -e .[dev]`  
+- `pip install -e '.[dev]'`  
   You can omit `[dev]` if you don't need to do serious development.
 
 #### *Or*: Install as library

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ INSTALL_REQUIRES = [
     'struct-tools==0.2.5',
     # TODO 5: replace by p-tqdm?
     'multiprocessing-on-dill==3.5.0a4',
-    'threadpoolctl==1.0.0',
+    'threadpoolctl>=3.0.0,<4.0.0',
 ]
 
 EXTRAS = {


### PR DESCRIPTION
Tried running `pytest` running Python 3.9 and `threadpoolctl` threw fits.
Things seem to run fine with the newest version of `threadpoolctl` so perhaps it's safe to upgrade?
