### PR TITLE
Updating QG F90 typing

### DIFF
--- a/dapper/mods/QG/f90/interface.f90
+++ b/dapper/mods/QG/f90/interface.f90
@@ -17,8 +17,9 @@ contains
 
     ! 1st axis (len N) is the x-axis
     ! 2nd axis (len M) is the y-axis (curl = sin(...y))
-    real(8), dimension(N, M) :: Q
+    real(8), allocatable, dimension(:, :) :: Q
     real(8) :: tstop
+    allocate(Q(N, M))
 
     call parameters_read(prmfname)
   

--- a/dapper/mods/QG/f90/qgflux.f90
+++ b/dapper/mods/QG/f90/qgflux.f90
@@ -44,8 +44,12 @@ contains
     real(8), dimension(:, :), intent(in) :: Q, PSIGUESS
     real(8), dimension(:, :), intent(out) :: PSI, QFLUX
 
-    real(8), dimension(N, M) :: JACOBIAN
-    real(8), dimension(N, M) :: ZETA, ZETA2, ZETA4
+    real(8), allocatable, dimension(:, :) :: JACOBIAN
+    real(8), allocatable, dimension(:, :) :: ZETA, ZETA2, ZETA4
+    allocate(JACOBIAN(N, M))
+    allocate(ZETA(N, M))
+    allocate(ZETA2(N, M))
+    allocate(ZETA4(N, M))
 
     call calc_psi(PSIGUESS, Q, PSI)
     call arakawa(PSI, Q, dx, dy, JACOBIAN)
@@ -68,8 +72,13 @@ contains
     real(8), dimension(:, :), intent(in) :: Q0, PSI0
     real(8), dimension(:, :), intent(out) :: PSI, QFLUX
 
-    real(8), dimension(N, M) :: J1, J2
-    real(8), dimension(N, M) :: ZETA, ZETA2, ZETA4
+    real(8), allocatable, dimension(:, :) :: J1, J2
+    real(8), allocatable, dimension(:, :) :: ZETA, ZETA2, ZETA4
+    allocate(J1(N, M))
+    allocate(J2(N, M))
+    allocate(ZETA(N, M))
+    allocate(ZETA2(N, M))
+    allocate(ZETA4(N, M))
 
     call calc_psi(PSIGUESS, Q, PSI)
     call arakawa(PSI0, Q, dx, dy, J1)

--- a/dapper/mods/QG/f90/qgstep.f90
+++ b/dapper/mods/QG/f90/qgstep.f90
@@ -28,8 +28,10 @@ contains
   subroutine qg_step_1storder(t, PSI, Q)
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: Q, PSI
-    real(8), dimension(N, M) :: QFLUX
-    real(8), dimension(N, M) :: PSI1
+    real(8), allocatable, dimension(:, :) :: QFLUX
+    real(8), allocatable, dimension(:, :) :: PSI1
+    allocate(QFLUX(N, M))
+    allocate(PSI1(N, M))
 
     call qg_flux(t, Q, PSI, PSI1, QFLUX)
     PSI = PSI1
@@ -40,10 +42,14 @@ contains
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: Q0, PSI0
     real(8), dimension(N, M), intent(inout) :: Q, PSI
-    real(8), dimension(N, M) :: QFLUX0
-    real(8), dimension(N, M) :: QFLUX
-    real(8), dimension(N, M) :: PSI01
-    real(8), dimension(N, M) :: PSI1
+    real(8), allocatable, dimension(:, :) :: QFLUX0
+    real(8), allocatable, dimension(:, :) :: QFLUX
+    real(8), allocatable, dimension(:, :) :: PSI01
+    real(8), allocatable, dimension(:, :) :: PSI1
+    allocate(QFLUX0(N, M))
+    allocate(QFLUX(N, M))
+    allocate(PSI01(N, M))
+    allocate(PSI1(N, M))
 
     call qg_flux(t, Q0, PSI0, PSI01, QFLUX0)
     call qg_flux_tl(t, Q0, PSI0, Q, PSI, PSI1, QFLUX)
@@ -56,9 +62,13 @@ contains
   subroutine qg_step_2ndorder(t, PSI, Q)
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: Q, PSI
-    real(8), dimension(N, M) :: QFLUX
-    real(8), dimension(N, M) :: PSI1
-    real(8), dimension(N, M) :: Q2, Q3
+    real(8), allocatable, dimension(:, :) :: QFLUX
+    real(8), allocatable, dimension(:, :) :: PSI1
+    real(8), allocatable, dimension(:, :) :: Q2, Q3
+    allocate(QFLUX(N, M))
+    allocate(PSI1(N, M))
+    allocate(Q2(N, M))
+    allocate(Q3(N, M))
 
     call qg_flux(t, Q, PSI, PSI1, QFLUX)
     Q2 = Q + (0.5d0 * dt) * QFLUX
@@ -74,12 +84,20 @@ contains
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: Q0, PSI0
     real(8), dimension(N, M), intent(inout) :: Q, PSI
-    real(8), dimension(N, M) :: QFLUX0
-    real(8), dimension(N, M) :: QFLUX
-    real(8), dimension(N, M) :: PSI01
-    real(8), dimension(N, M) :: PSI1
-    real(8), dimension(N, M) :: Q02, Q03
-    real(8), dimension(N, M) :: Q2, Q3
+    real(8), allocatable, dimension(:, :) :: QFLUX0
+    real(8), allocatable, dimension(:, :) :: QFLUX
+    real(8), allocatable, dimension(:, :) :: PSI01
+    real(8), allocatable, dimension(:, :) :: PSI1
+    real(8), allocatable, dimension(:, :) :: Q02, Q03
+    real(8), allocatable, dimension(:, :) :: Q2, Q3
+    allocate(QFLUX0(N, M))
+    allocate(QFLUX(N, M))
+    allocate(PSI01(N, M))
+    allocate(PSI1(N, M))
+    allocate(Q02(N, M))
+    allocate(Q03(N, M))
+    allocate(Q2(N, M))
+    allocate(Q3(N, M))
 
     call qg_flux(t, Q0, PSI0, PSI01, QFLUX0)
     call qg_flux_tl(t, Q0, PSI0, Q, PSI, PSI1, QFLUX)
@@ -100,10 +118,18 @@ contains
   subroutine qg_step_rk4(t, PSI, Q)
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: Q, PSI
-    real(8), dimension(N, M) :: QFLUX1, QFLUX2, QFLUX3, QFLUX4
-    real(8), dimension(N, M) :: PP
-    real(8), dimension(N, M) :: Q2, Q3, Q4
+    real(8), allocatable, dimension(:, :) :: QFLUX1, QFLUX2, QFLUX3, QFLUX4
+    real(8), allocatable, dimension(:, :) :: PP
+    real(8), allocatable, dimension(:, :) :: Q2, Q3, Q4
     real(8) :: tt
+    allocate(QFLUX1(N, M))
+    allocate(QFLUX2(N, M))
+    allocate(QFLUX3(N, M))
+    allocate(QFLUX4(N, M))
+    allocate(PP(N, M))
+    allocate(Q2(N, M))
+    allocate(Q3(N, M))
+    allocate(Q4(N, M))
 
     ! Given vorticity Q, this call calculates its flux QFLUX1. 
     ! Solves for PSI1 as a by-product, using PSI as the first guess
@@ -126,13 +152,29 @@ contains
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: Q0, PSI0
     real(8), dimension(N, M), intent(inout) :: Q, PSI
-    real(8), dimension(N, M) :: QFLUX01, QFLUX02, QFLUX03, QFLUX04
-    real(8), dimension(N, M) :: QFLUX1, QFLUX2, QFLUX3, QFLUX4
-    real(8), dimension(N, M) :: PP0
-    real(8), dimension(N, M) :: PP
-    real(8), dimension(N, M) :: Q02, Q03, Q04
-    real(8), dimension(N, M) :: Q2, Q3, Q4
+    real(8), allocatable, dimension(:, :) :: QFLUX01, QFLUX02, QFLUX03, QFLUX04
+    real(8), allocatable, dimension(:, :) :: QFLUX1, QFLUX2, QFLUX3, QFLUX4
+    real(8), allocatable, dimension(:, :) :: PP0
+    real(8), allocatable, dimension(:, :) :: PP
+    real(8), allocatable, dimension(:, :) :: Q02, Q03, Q04
+    real(8), allocatable, dimension(:, :) :: Q2, Q3, Q4
     real(8) :: tt
+    allocate(QFLUX01(N, M))
+    allocate(QFLUX02(N, M))
+    allocate(QFLUX03(N, M))
+    allocate(QFLUX04(N, M))
+    allocate(QFLUX1(N, M))
+    allocate(QFLUX2(N, M))
+    allocate(QFLUX3(N, M))
+    allocate(QFLUX4(N, M))
+    allocate(PP0(N, M))
+    allocate(PP(N, M))
+    allocate(Q02(N, M))
+    allocate(Q03(N, M))
+    allocate(Q04(N, M))
+    allocate(Q2(N, M))
+    allocate(Q3(N, M))
+    allocate(Q4(N, M))
 
     ! Given vorticity Q, this call calculates its flux QFLUX1. 
     ! Solves for PSI1 as a by-product, using PSI as the first guess
@@ -162,9 +204,16 @@ contains
   subroutine qg_step_dp5(t, PSI, Q)
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: Q, PSI
-    real(8), dimension(N, M) :: QFLUX1, QFLUX2, QFLUX3, QFLUX4, QFLUX5
-    real(8), dimension(N, M) :: QQ, PP
+    real(8), allocatable, dimension(:, :) :: QFLUX1, QFLUX2, QFLUX3, QFLUX4, QFLUX5
+    real(8), allocatable, dimension(:, :) :: QQ, PP
     real(8) :: tt
+    allocate(QFLUX1(N, M))
+    allocate(QFLUX2(N, M))
+    allocate(QFLUX3(N, M))
+    allocate(QFLUX4(N, M))
+    allocate(QFLUX5(N, M))
+    allocate(QQ(N, M))
+    allocate(PP(N, M))
 
     call qg_flux(t, Q, PSI, PP, QFLUX1)
     tt = t + 0.2d0 * dt
@@ -204,8 +253,11 @@ contains
   subroutine qg_step_lf(t, PSIGUESS, QOLD, Q)
     real(8), intent(inout) :: t
     real(8), dimension(N, M), intent(inout) :: PSIGUESS, QOLD, Q
-    real(8), dimension(N, M) :: PSI
-    real(8), dimension(N, M) :: QNEW, QFLUX
+    real(8), allocatable, dimension(:, :) :: PSI
+    real(8), allocatable, dimension(:, :) :: QNEW, QFLUX
+    allocate(PSI(N, M))
+    allocate(QNEW(N, M))
+    allocate(QFLUX(N, M))
 
     call qg_flux(t, Q, PSIGUESS, PSI, QFLUX)
     QNEW = QOLD + (2.0d0 * dt) * QFLUX


### PR DESCRIPTION
f2py was giving warnings / errors over the size of arrays exceeding stack sizes
on my cluser environment, yet I couldn't seem to find a way to change the
stack size with ulimit commands or to pass a `-fmax-stack-var-size=` or 
a `frecursive` build option to gfortran through f2py as per the warning message. 
Changing the typing to allocatable and allocating the arrays in their instance as per
https://www.scivision.dev/gfortran-stack-to-static-warning/
fixed these compile issues.  Example issue is copied below:

```
qgflux.f90:71:34:

   71 |     real(8), dimension(N, M) :: J1, J2
      |                                  1
Warning: Array 'j1' at (1) is larger than limit set by '-fmax-stack-var-size=', moved from stack to static storage. This makes the procedure unsafe when called recursively, or concurrently from multiple threads. Consider using '-frecursive', or increase the '-fmax-stack-var-size=' limit, or change the code to use an ALLOCATABLE array. [-Wsurprising]
qgflux.f90:71:38:

```